### PR TITLE
Use Viper to process environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ go build -o fileserver main.go
 |PORT     |`8080` |Port the fileserver is listening on         |
 |FILE_ROOT|`./` |File root of the fileserver on the machine  |
 
+The configuration is now managed using the Viper framework. Viper reads the environment variables and provides default values if they are not set.
+
 ## Usage: Application
 You can run the application as-is. No flags or parameters are required.
 ```

--- a/main.go
+++ b/main.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"github.com/rmeulen/go-fileserver/fileserver"
+	"github.com/spf13/viper"
 	"fmt"
 	"log"
 	"net/http"
-	"os"
-	"strconv"
 )
 
 const portEnvName = "PORT"
@@ -17,8 +16,12 @@ const defaultFileRoot = "./"
 
 func main() {
 
-	port := determinePort()
-	fileRoot := determineFileRoot()
+	viper.SetDefault(portEnvName, defaultPort)
+	viper.SetDefault(fileRootEnvName, defaultFileRoot)
+	viper.AutomaticEnv()
+
+	port := viper.GetInt(portEnvName)
+	fileRoot := viper.GetString(fileRootEnvName)
 
 	fileServer := fileserver.CreateHandler(fileRoot)
 
@@ -26,38 +29,4 @@ func main() {
 	log.Printf("Using file root: %s", fileRoot)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), fileServer))
 
-}
-
-func determinePort() int {
-	portEnvValue := os.Getenv(portEnvName)
-
-	if portEnvValue == "" {
-		log.Printf("No value found for environment variable %s.", portEnvName)
-		log.Printf("Using default port number: %d", defaultPort)
-		return defaultPort
-	}
-
-	port, err := strconv.Atoi(portEnvValue)
-
-	if err != nil {
-		log.Printf("Invalid value for environment variable %s", portEnvName)
-		log.Printf("Defaulting to port number: %d", defaultPort)
-		return defaultPort
-	}
-
-	log.Printf("Valid environment variable %s found: %d", portEnvName, port)
-	return port
-}
-
-func determineFileRoot() string {
-	fileRoot := os.Getenv(fileRootEnvName)
-
-	if fileRoot == "" {
-		log.Printf("No value found for environment variable %s", fileRootEnvName)
-		log.Printf("Defaulting to file root: %s", defaultFileRoot)
-		fileRoot = defaultFileRoot
-	}
-
-	log.Printf("Valid environment variable %s found: %s", fileRootEnvName, fileRoot)
-	return fileRoot
 }


### PR DESCRIPTION
Fixes #1

Update `main.go` to use Viper for environment variable processing.

* Import the `github.com/spf13/viper` package.
* Remove the `determinePort` and `determineFileRoot` functions.
* Use Viper to read the `PORT` and `FILE_ROOT` environment variables with default values of `8080` and `./` respectively.

Update `README.md` to reflect the use of Viper for configuration.

* Add a note about Viper managing the configuration and providing default values for environment variables.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rmeulen/go-fileserver/issues/1?shareId=c50eb0aa-23c3-4f6d-92d3-e15b20aeaba6).