### PR TITLE
Create GitHub Actions workflow to build and push Docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,7 +23,7 @@ jobs:
       run: docker build -t ghcr.io/${{ github.repository }}/fileserver:${{ github.sha }} .
 
     - name: Add test data
-      run: echo "This is a test file." > testdata/testfile.txt
+      run: mkdir -p testdata && echo "This is a test file." > testdata/testfile.txt
 
     - name: Test the Docker image
       run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,37 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v2
+
+    - name: Log in to GitHub Packages
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+    - name: Build the Docker image
+      run: docker build -t ghcr.io/${{ github.repository }}/fileserver:${{ github.sha }} .
+
+    - name: Add test data
+      run: echo "This is a test file." > testdata/testfile.txt
+
+    - name: Test the Docker image
+      run: |
+        docker run -d -p 8080:8080 -v $(pwd)/testdata:/root --name fileserver ghcr.io/${{ github.repository }}/fileserver:${{ github.sha }}
+        sleep 10
+        curl -f http://localhost:8080/testfile.txt || (docker logs fileserver && exit 1)
+        docker stop fileserver
+        docker rm fileserver
+
+    - name: Push the Docker image
+      run: docker push ghcr.io/${{ github.repository }}/fileserver:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/rmeulen/go-fileserver.svg?branch=master)](https://travis-ci.org/rmeulen/go-fileserver)
 [![Go Report Card](https://goreportcard.com/badge/github.com/rmeulen/go-fileserver)](https://goreportcard.com/report/github.com/rmeulen/go-fileserver)
+[![Build and Push Docker Image](https://github.com/rmeulen/go-fileserver/actions/workflows/docker-image.yml/badge.svg)](https://github.com/rmeulen/go-fileserver/actions/workflows/docker-image.yml)
 # go-fileserver
 A simple fileserver written in Go (1.12)
 


### PR DESCRIPTION
Add GitHub Actions workflow to build and push Docker image to GitHub Packages.

* **Workflow file**: Create `.github/workflows/docker-image.yml` to define the workflow for building and pushing the Docker image.
  - Add steps to check out the repository, log in to GitHub Packages, build the Docker image, and push it to the registry.
  - Include a step to add test data and test the Docker image by accessing a local file through the fileserver.

* **README.md**: Update to include a badge for the GitHub Actions workflow status.
  - Remove the Travis CI badge.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rmeulen/go-fileserver/pull/10?shareId=260983bd-873d-4260-a417-2263f587b970).