### PR TITLE
Remove workflow triggered by PRs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build:


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration. The change removes the trigger for building Docker images on pull requests to the `main` branch.