### PR TITLE
Add go outdated dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,9 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "Docker" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/fileserver/fileserver.go
+++ b/fileserver/fileserver.go
@@ -2,7 +2,13 @@ package fileserver
 
 import (
 	"net/http"
+
+	"github.com/google/uuid"
 )
+
+func init() {
+	_ = uuid.New()
+}
 
 func CreateHandler(fileRoot string) http.Handler {
 	directory := http.Dir(fileRoot)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
+go 1.12
+
 module github.com/rmeulen/go-fileserver
 
-go 1.12
+require github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
This pull request introduces configuration updates for Dependabot and adds a new dependency to the `fileserver` package. The most important changes include enabling daily updates for Go modules and Docker images, and integrating the `uuid` library into the `fileserver` package.

### Dependabot Configuration Updates:
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L1-R6): Added daily update schedules for Go modules (`gomod`) and Docker images. This ensures dependencies are checked and updated more frequently.

### Integration of `uuid` Library:
* [`fileserver/fileserver.go`](diffhunk://#diff-cc88b3b39cdcbf37e9101e6bfaaf7b005ef97980c6be10d8cc695dadd84e4011R5-R12): Imported the `uuid` library and added an initialization block to ensure the library is loaded.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R1-R5): Added a new dependency on `github.com/google/uuid` version `v1.1.2`.