### PR TITLE
Update dependabot configuration to set Docker package updates to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
-  - package-ecosystem: "Docker" # See documentation for possible values
-    directory: "/" # Location of package manifests
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change adjusts the update interval for Go modules from daily to weekly and standardizes the casing for the Docker package-ecosystem identifier.