### PR TITLE
Add Go Dev Container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Go Dev Container",
+  "image": "mcr.microsoft.com/devcontainers/go:1.22",
+  "features": {},
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.Go"
+      ]
+    }
+  },
+  "postCreateCommand": "go mod tidy"
+}


### PR DESCRIPTION
This pull request introduces a new development container configuration for Go. It sets up a dev container using an official Go image, installs the Go extension for VS Code, and runs `go mod tidy` after the container is created.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R1-R13): Added a new dev container configuration for Go, specifying the image `mcr.microsoft.com/devcontainers/go:1.22`, installing the `golang.Go` VS Code extension, and running `go mod tidy` as a post-create command.